### PR TITLE
Introduced first-party icons for support

### DIFF
--- a/_snippets/snippet-example.mdx
+++ b/_snippets/snippet-example.mdx
@@ -1,3 +1,0 @@
-## My Snippet
-
-<Info>This is an example of a reusable snippet</Info>

--- a/connections/integrations/bigquery.mdx
+++ b/connections/integrations/bigquery.mdx
@@ -3,6 +3,7 @@ title: "BigQuery"
 description: "Setting up a connection with BigQuery"
 ---
 
+import { IsSupportedIcon } from '/snippets/icons.mdx';
 
 ## Installation Instructions
 
@@ -601,9 +602,9 @@ This integration supports the following Converge connection functionality.
 
 | Converge Feature   &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;                            | Supported                                       |  
 | -------------------------------------------- | -------------------------------------------------------- |  
-| Custom Events          | ✅                       | 
-| Filters         | ✅         |  
-| Server-side Conversions | ✅  |
+| Custom Events          | <IsSupportedIcon isSupported={true}/>                       | 
+| Filters         | <IsSupportedIcon isSupported={true}/>         |  
+| Server-side Conversions | <IsSupportedIcon isSupported={true}/>  |
 
 ---
 

--- a/connections/integrations/bing.mdx
+++ b/connections/integrations/bing.mdx
@@ -3,6 +3,8 @@ title: "Bing Ads"
 description: "An introduction to the Bing Ads Destination"
 ---
 
+import { IsSupportedIcon } from '/snippets/icons.mdx';
+
 ## Installation Instructions
 
 <AccordionGroup >
@@ -42,9 +44,9 @@ This integration supports the following Converge connection functionality.
 
 | Converge Feature   &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;                            | Supported                                       |  
 | -------------------------------------------- | -------------------------------------------------------- |  
-| Custom Events          | ✅                       | 
-| Filters         | ❌         |  
-| Server-side Conversions | ❌ |
+| Custom Events          | <IsSupportedIcon isSupported={true}/>                       | 
+| Filters         | <IsSupportedIcon isSupported={false}/>       |  
+| Server-side Conversions | <IsSupportedIcon isSupported={false}/>  |
 
 
 --- 

--- a/connections/integrations/facebook.mdx
+++ b/connections/integrations/facebook.mdx
@@ -3,6 +3,8 @@ title: "Meta"
 description: "An introduction to the Meta/Facebook Ads Destination"
 ---
 
+import { IsSupportedIcon } from '/snippets/icons.mdx';
+
 ## Installation Instructions
 
 <AccordionGroup >
@@ -43,9 +45,9 @@ This integration supports the following Converge connection functionality.
 
 | Converge Feature   &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;                            | Supported                                       |  
 | -------------------------------------------- | -------------------------------------------------------- |  
-| Custom Events          | ✅                       | 
-| Filters         | ✅         |  
-| Server-side Conversions | ✅  |
+| Custom Events          |  <IsSupportedIcon isSupported={true}/>                  | 
+| Filters         | <IsSupportedIcon isSupported={true}/>       |  
+| Server-side Conversions | <IsSupportedIcon isSupported={true}/>  |
 
 
 --- 

--- a/connections/integrations/ga4.mdx
+++ b/connections/integrations/ga4.mdx
@@ -3,6 +3,7 @@ title: "Google Analytics 4"
 description: "Setting up a connection with GA4"
 ---
 
+import { IsSupportedIcon } from '/snippets/icons.mdx';
 
 ## Installation Instructions
 
@@ -60,9 +61,9 @@ This integration supports the following Converge connection functionality.
 
 | Converge Feature   &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;                            | Supported                                       |  
 | -------------------------------------------- | -------------------------------------------------------- |  
-| Custom Events          | ✅                       | 
-| Filters         | ✅         |  
-| Server-side Conversions | ✅  |
+| Custom Events          | <IsSupportedIcon isSupported={true}/>                       | 
+| Filters         | <IsSupportedIcon isSupported={true}/>         |  
+| Server-side Conversions | <IsSupportedIcon isSupported={true}/>  |
 
 --- 
 

--- a/connections/integrations/google-ads.mdx
+++ b/connections/integrations/google-ads.mdx
@@ -3,6 +3,8 @@ title: "Google Ads"
 description: "An introduction to the Google Ads Destination"
 ---
 
+import { IsSupportedIcon } from '/snippets/icons.mdx';
+
 ## Installation Instructions
 
 <AccordionGroup >
@@ -63,9 +65,9 @@ This integration supports the following Converge connection functionality.
 
 | Converge Feature   &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;                            | Supported                                       |  
 | -------------------------------------------- | -------------------------------------------------------- |  
-| Custom Events          | ✅                       | 
-| Filters         | ❌         |  
-| Server-side Conversions | ❌ |
+| Custom Events          | <IsSupportedIcon isSupported={true}/>                       | 
+| Filters         | <IsSupportedIcon isSupported={false}/>       |  
+| Server-side Conversions | <IsSupportedIcon isSupported={false}/>  |
 
 
 --- 

--- a/connections/integrations/tiktok.mdx
+++ b/connections/integrations/tiktok.mdx
@@ -3,6 +3,8 @@ title: "TikTok Ads"
 description: "An introduction to the TikTok Ads Destination"
 ---
 
+import { IsSupportedIcon } from '/snippets/icons.mdx';
+
 ## Installation Instructions
 
 <AccordionGroup >
@@ -44,9 +46,9 @@ This integration supports the following Converge connection functionality.
 
 | Converge Feature   &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp;  &nbsp;                            | Supported                                       |  
 | -------------------------------------------- | -------------------------------------------------------- |  
-| Custom Events          | ✅                       | 
-| Filters         | ✅         |  
-| Server-side Conversions | ✅  |
+| Custom Events          | <IsSupportedIcon isSupported={true}/>                       | 
+| Filters         | <IsSupportedIcon isSupported={true}/>         |  
+| Server-side Conversions | <IsSupportedIcon isSupported={true}/>  |
 
 
 --- 

--- a/snippets/icons.mdx
+++ b/snippets/icons.mdx
@@ -1,0 +1,16 @@
+export const IsSupportedIcon = ({ isSupported }) => {
+  const iconName = isSupported ? "check" : "xmark";
+
+  return (
+    <div className="h-4 w-4 fill-gray-800 dark:fill-gray-100 text-gray-800 dark:text-gray-100 pt-1 ml-6">
+      <svg
+        className="w-4 h-4 bg-gray-800 dark:bg-gray-100"
+        style={{
+          maskImage: `url('https://mintlify.b-cdn.net/v6.5.1/regular/${iconName}.svg')`,
+          maskRepeat: "no-repeat",
+          maskPosition: "center center"
+        }}
+      ></svg>
+    </div>
+  );
+};


### PR DESCRIPTION
Looks like this now: 

<img width="661" alt="Screenshot 2024-03-11 at 16 37 19" src="https://github.com/run-converge/docs-mintlify/assets/31068156/40e360b2-eb06-407e-b58c-439c7b325cf0">

or dark mode:

<img width="685" alt="Screenshot 2024-03-11 at 16 40 23" src="https://github.com/run-converge/docs-mintlify/assets/31068156/677b27f3-6df1-4b5e-9c7e-759a17778d24">


The logic for this lives in a separate component:

```jsx
import { IsSupportedIcon } from '/snippets/icons.mdx';

<IsSupportedIcon isSupported={true}/> 

```

The icons get centered in the table column across mobile and web from what I can tell but did this quite scrappily so might be off. In any case quite a big improvement imo